### PR TITLE
refactor: remove unused ranking field from athlons collection

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -117,10 +117,6 @@ export const onScoreChanged = onDocumentWritten(
 
 			const ranking = calculateRanking(gameDocs, scoreDocs);
 
-			transaction.update(athlon, {
-				ranking,
-			});
-
 			const athlonRankings = athlon.collection('rankings') as CollectionReference<AthlonRanking>;
 
 			for (const rankingEntry of ranking) {


### PR DESCRIPTION
## Summary

- `functions/src/index.ts` の `transaction.update(athlon, { ranking })` を削除（`rankings` サブコレクションへの書き込みは引き続き行われる）
- DB上の既存ドキュメントから `ranking` フィールドを一時スクリプトで削除済み（2025, 2026, system-test の3件）

## Test plan

- [ ] スコア更新時に `rankings` サブコレクションが正しく更新されることを確認
- [ ] アスロンドキュメント本体に `ranking` フィールドが書き込まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)