### PR TITLE
feat: quantum-computing・esolang競技ページのadminプレビュー機能を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,64 @@ This is a monorepo with two deployable units:
 - The frontend reads rankings and scores in real-time via Firestore subscriptions
 - Rankings are pre-computed and stored; the frontend does not calculate them
 
+### Code Execution Pipeline
+
+For game types that run code (esolang, codegolf, quantum-computing, sql, reversing-diff), Firebase Cloud Functions and the **esolang-battle-2** worker (separate repo at `../esolang-battle-2`) collaborate via a BullMQ queue backed by Redis.
+
+#### Regular submission (`games/{gameId}/submissions/{submissionId}`)
+
+```
+Frontend
+  └─ addDoc → games/{gameId}/submissions/{id}  status: 'pending'
+        │
+        ▼ Firestore trigger
+functions/src/submissions.ts: onSubmissionCreated
+  ├─ Validate submission (adjacency check, etc.)
+  ├─ Update status → 'executing'
+  └─ Enqueue job to BullMQ queue "decathlon"
+       { gameId, submissionId, imageId, code (base64), testcases }
+        │
+        ▼ esolang-battle-2 Worker
+apps/worker/src/jobs/decathlon.ts: processDecathlonSubmission
+  ├─ runAllTestCasesInSingleContainer() — runs Docker container (timeout: 20s)
+  └─ Write to executions/{submissionId} in Firestore
+       { gameId, submissionId, results[], error, completedAt }
+        │
+        ▼ Firestore trigger
+functions/src/executions.ts: onExecutionCreated
+  ├─ Route to handler based on gameId/rule
+  │   processEsolangExecution / processCodegolfExecution / etc.
+  ├─ Update submission status and testcases (success / failed / error)
+  └─ On success: update ranking and score
+```
+
+#### Esolang code test (`esolangTestSubmissions/{submissionId}`)
+
+```
+Frontend
+  └─ addDoc → esolangTestSubmissions/{id}  status: 'pending'
+        │
+        ▼ Firestore trigger
+functions/src/submissions.ts: onEsolangTestSubmissionCreated
+  ├─ Update status → 'executing'
+  └─ Enqueue job to BullMQ queue "decathlon"
+       { gameId: 'esolang-test', submissionId, imageId, code (base64), testcases }
+        │
+        ▼ esolang-battle-2 Worker (same processDecathlonSubmission flow)
+        │
+        ▼ Firestore trigger
+functions/src/executions.ts: onExecutionCreated → processEsolangTestExecution
+  └─ Update esolangTestSubmissions/{id}: status, stdout, stderr, duration
+       (success / error)
+```
+
+#### Key notes
+
+- The **esolang-battle-2 Worker** runs as a separate process (separate server) and connects to the same Firebase project (`tsg-decathlon`) Firestore and the same Redis instance.
+- Code is passed to BullMQ jobs as base64 (`codeEncoding: 'base64'`).
+- If the worker fails to write to `executions/` after Docker execution, the submission status stays stuck at `'executing'` forever. The frontend has a 90-second client-side timeout as a safety net (`src/routes/arenas/esolang.tsx`).
+- The `executions/` collection acts as a one-way handoff: the worker writes, Cloud Functions read and react.
+
 ## Tech Stack
 
 - **Frontend**: Solid.js, SolidStart, Vinxi, SUID (Material Design), SCSS

--- a/src/app.css
+++ b/src/app.css
@@ -58,7 +58,7 @@ a {
 
 pre {
 	background: #f4f6f6;
-	font-size: 1.2em;
+	font-size: 1.1em;
 	margin: 0;
 	padding: 0.5rem;
 	line-height: 1em;

--- a/src/routes/arenas/esolang.tsx
+++ b/src/routes/arenas/esolang.tsx
@@ -1165,6 +1165,24 @@ const Esolang = () => {
 	const gameRef = doc(db, 'games', gameId) as DocumentReference<Game>;
 	const gameData = useFirestore(gameRef);
 
+	const isGameAdmin = createMemo(() => {
+		const uid = user()?.uid;
+		const admins = gameData.data?.admins;
+		if (!uid || !admins) {
+			return false;
+		}
+		return admins.includes(uid);
+	});
+
+	const effectivePhase = createMemo(() => {
+		if (phase() === 'waiting' && isGameAdmin()) {
+			return 'playing' as const;
+		}
+		return phase();
+	});
+
+	const adminViewingUnpublished = createMemo(() => phase() === 'waiting' && isGameAdmin());
+
 	setArenaTitle('難解プログラミング言語');
 
 	createEffect(() => {
@@ -1173,7 +1191,7 @@ const Esolang = () => {
 			const rankingRef = doc(db, `games/${gameId}/ranking/${userData.uid}`) as DocumentReference<EsolangRanking>;
 			setMyRanking(useFirestore(rankingRef));
 
-			if (phase() === 'playing') {
+			if (effectivePhase() === 'playing') {
 				setSubmissions(useFirestore(
 					query(
 						collection(gameRef, 'submissions') as CollectionReference<EsolangSubmission>,
@@ -1181,7 +1199,7 @@ const Esolang = () => {
 						orderBy('createdAt', 'desc'),
 					),
 				));
-			} else if (phase() === 'finished') {
+			} else if (effectivePhase() === 'finished') {
 				setSubmissions(useFirestore(
 					query(
 						collection(gameRef, 'submissions') as CollectionReference<EsolangSubmission>,
@@ -1232,14 +1250,19 @@ const Esolang = () => {
 
 	return (
 		<Switch>
-			<Match when={phase() === 'waiting'}>
+			<Match when={effectivePhase() === 'waiting'}>
 				<Typography variant="h3" component="p" textAlign="center" py={6}>
 					競技開始までしばらくお待ち下さい。
 				</Typography>
 			</Match>
-			<Match when={phase() === 'playing' || phase() === 'finished'}>
+			<Match when={effectivePhase() === 'playing' || effectivePhase() === 'finished'}>
 				<main>
 					<Container maxWidth="lg" sx={{py: 3}}>
+						<Show when={adminViewingUnpublished()}>
+							<Alert severity="warning" sx={{mb: 1}}>
+								この競技はまだ公開されていません。あなたはこのゲームのadminのため、閲覧・提出が可能です。
+							</Alert>
+						</Show>
 						<Alert severity="info" sx={{mb: 2}}>
 							盤面上のプログラミング言語でコードを提出し、マスを獲得してください。
 							獲得済みのマスに隣接するマス（青色）のみ提出できます。
@@ -1274,7 +1297,7 @@ const Esolang = () => {
 						</Box>
 						<Switch>
 							<Match when={searchParams.tab === 'main'}>
-								<MainTab myRanking={myRanking()} phase={phase()}/>
+								<MainTab myRanking={myRanking()} phase={effectivePhase()}/>
 							</Match>
 							<Match when={searchParams.tab === 'submissions'}>
 								<SubmissionsTab submissions={submissions()}/>

--- a/src/routes/arenas/esolang.tsx
+++ b/src/routes/arenas/esolang.tsx
@@ -873,6 +873,7 @@ const TestTab = () => {
 	const [initialized, setInitialized] = createSignal(false);
 
 	let testFileInputRef!: HTMLInputElement;
+	let executingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 	// Initialize from URL params (e.g. after clicking a sample filename)
 	createEffect(() => {
@@ -930,12 +931,21 @@ const TestTab = () => {
 			setTestStatus('ready');
 		}
 	}, 1000);
-	onCleanup(() => clearInterval(intervalId));
+	onCleanup(() => {
+		clearInterval(intervalId);
+		if (executingTimeoutId !== null) {
+			clearTimeout(executingTimeoutId);
+		}
+	});
 
 	createEffect(() => {
 		const result = testResult();
 		if (testStatus() === 'executing') {
 			if ((['success', 'error'] as (string | undefined)[]).includes(result?.data?.status)) {
+				if (executingTimeoutId !== null) {
+					clearTimeout(executingTimeoutId);
+					executingTimeoutId = null;
+				}
 				setTestStatus('throttled');
 			}
 		}
@@ -961,6 +971,16 @@ const TestTab = () => {
 
 		setTestResult(null);
 		setTestStatus('executing');
+
+		if (executingTimeoutId !== null) {
+			clearTimeout(executingTimeoutId);
+		}
+		executingTimeoutId = setTimeout(() => {
+			executingTimeoutId = null;
+			if (testStatus() === 'executing') {
+				setTestStatus('throttled');
+			}
+		}, 90000);
 
 		const testRef = await addDoc(
 			collection(db, 'esolangTestSubmissions') as CollectionReference<EsolangTestSubmission>,

--- a/src/routes/arenas/quantum-computing.tsx
+++ b/src/routes/arenas/quantum-computing.tsx
@@ -467,12 +467,30 @@ const QuantumComputing = () => {
 	const gameRef = doc(db, 'games', gameId) as DocumentReference<Game>;
 	const gameData = useFirestore(gameRef);
 
+	const isGameAdmin = createMemo(() => {
+		const uid = user()?.uid;
+		const admins = gameData.data?.admins;
+		if (!uid || !admins) {
+			return false;
+		}
+		return admins.includes(uid);
+	});
+
+	const effectivePhase = createMemo(() => {
+		if (phase() === 'waiting' && isGameAdmin()) {
+			return 'playing' as const;
+		}
+		return phase();
+	});
+
+	const adminViewingUnpublished = createMemo(() => phase() === 'waiting' && isGameAdmin());
+
 	setArenaTitle('diff');
 
 	createEffect(() => {
 		const userData = user();
 		if (userData?.uid) {
-			if (phase() === 'playing') {
+			if (effectivePhase() === 'playing') {
 				const submissionsData = useFirestore(
 					query(
 					collection(gameRef, 'submissions') as CollectionReference<QuantumComputingSubmission>,
@@ -481,7 +499,7 @@ const QuantumComputing = () => {
 					),
 				);
 				setSubmissions(submissionsData);
-			} else if (phase() === 'finished') {
+			} else if (effectivePhase() === 'finished') {
 				const submissionsData = useFirestore(
 					query(
 					collection(gameRef, 'submissions') as CollectionReference<QuantumComputingSubmission>,
@@ -546,7 +564,7 @@ const QuantumComputing = () => {
 
 	return (
 		<Switch>
-			<Match when={phase() === 'waiting'}>
+			<Match when={effectivePhase() === 'waiting'}>
 				<Typography
 					variant="h3"
 					component="p"
@@ -557,10 +575,15 @@ const QuantumComputing = () => {
 				</Typography>
 			</Match>
 			<Match
-				when={phase() === 'playing' || phase() === 'finished'}
+				when={effectivePhase() === 'playing' || effectivePhase() === 'finished'}
 			>
 				<main class={styles.app}>
 					<Container maxWidth="lg" sx={{py: 3}}>
+						<Show when={adminViewingUnpublished()}>
+							<Alert severity="warning" sx={{mb: 1}}>
+								この競技はまだ公開されていません。あなたはこのゲームのadminのため、閲覧・提出が可能です。
+							</Alert>
+						</Show>
 						<Alert severity="info">
 							与えられた条件を満たす量子回路を設計し、Pythonコードとして提出してください。
 						</Alert>
@@ -582,7 +605,7 @@ const QuantumComputing = () => {
 						</Box>
 						<Switch>
 							<Match when={searchParams.tab === 'main'}>
-								<MainTab phase={phase()}/>
+								<MainTab phase={effectivePhase()}/>
 							</Match>
 							<Match when={searchParams.tab === 'submissions'}>
 								<SubmissionsTab submissions={submissions()} config={config()}/>


### PR DESCRIPTION
## Summary

- `game.admins` に含まれるユーザーは、`enabled: false`（未公開）のquantum-computing・esolang競技でも問題の閲覧・提出が可能になった
- 未公開の競技をadminとして閲覧している場合、「この競技はまだ公開されていません。あなたはこのゲームのadminのため、閲覧・提出が可能です。」という警告バナーを表示する

## 実装の詳細

両競技ページで共通の実装:
- `isGameAdmin` memo: `gameData.data.admins` に現在のユーザーのUIDが含まれるかチェック
- `effectivePhase` memo: phaseが `waiting` かつ `isGameAdmin` なら `playing` として扱う
- `adminViewingUnpublished` memo: 未公開競技をadminとして閲覧中かどうかのフラグ
- 提出一覧の読み込みロジックおよびJSXのSwitch/Matchを `effectivePhase()` に統一

## Test plan

- [ ] adminユーザーで未公開（`enabled: false`）のquantum-computing競技URLにアクセスし、問題が表示されることを確認
- [ ] adminユーザーで未公開（`enabled: false`）のesolang競技URLにアクセスし、盤面が表示されることを確認
- [ ] 両競技で警告バナー「この競技はまだ公開されていません。あなたはこのゲームのadminのため、閲覧・提出が可能です。」が表示されることを確認
- [ ] 両競技でadminユーザーによる提出ができることを確認
- [ ] 非adminユーザーでは「競技開始までしばらくお待ち下さい。」が表示されることを確認
- [ ] 公開済み（`enabled: true`）の競技では通常通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)