### PR TITLE
fix: address SonarQube issues (Number.parseInt, alt attrs, codePoint APIs)

### DIFF
--- a/functions/src/executions.ts
+++ b/functions/src/executions.ts
@@ -9,14 +9,14 @@ import {db, storage} from './firebase.js';
 const normalizeCodegolfOutput = (text: string, judgeType: CodegolfJudgeType) => {
 	if (judgeType === 'ignore-newline-type') {
 		return text
-			.replaceAll(/\r\n/g, '\n')
+			.replaceAll('\r\n', '\n')
 			.replace(/\n+$/, '');
 	}
 	if (judgeType === 'number-sequence-ignore-whitespaces') {
 		return text
 			.trim()
 			.split(/\s+/)
-			.map((s) => parseFloat(s).toString())
+			.map((s) => Number.parseFloat(s).toString())
 			.join(' ');
 	}
 	return text.replaceAll(/\s/g, '');
@@ -261,7 +261,7 @@ const processReversingDiffExecution = async (
 		error = 'stdout is not a valid format';
 	}
 
-	let score = error ? null : parseInt(stdout);
+	let score = error ? null : Number.parseInt(stdout);
 	if (score !== null && !Number.isFinite(score)) {
 		score = null;
 	}
@@ -286,7 +286,7 @@ const processReversingDiffExecution = async (
 	}
 
 	const [fileMetadata] = await storage.bucket().file(`assets/reversing-diff/${mainFile.filename}`).getMetadata();
-	const fileSize = parseInt(String(fileMetadata.size));
+	const fileSize = Number.parseInt(String(fileMetadata.size));
 	logInfo(`correct file size: ${fileSize}`);
 
 	const batch = db.batch();

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -46,7 +46,7 @@ const LoginButton = () => {
 					{loginErrorMessage()}
 				</DialogTitle>
 				<DialogContent>
-					<img src="https://user-images.githubusercontent.com/3126484/230712207-9e179595-8337-47fc-9ccd-dd060a862b6d.png" width="100%"/>
+					<img src="https://user-images.githubusercontent.com/3126484/230712207-9e179595-8337-47fc-9ccd-dd060a862b6d.png" width="100%" alt=""/>
 					<DialogContentText>
 						ログイン用のポップアップが表示されたら、右上のワークスペースが「TSG」になっているのを確認した上で「許可する」を押してください。(「TSG」でない場合は選択してください)
 					</DialogContentText>

--- a/src/components/RankingSummary.tsx
+++ b/src/components/RankingSummary.tsx
@@ -16,7 +16,7 @@ const RankingSummary = (props: Props) => (
 					size="large"
 					direction="column"
 					accessory={
-						<img src="/images/crown-solid.svg" class={styles.crown}/>
+						<img src="/images/crown-solid.svg" class={styles.crown} alt=""/>
 					}
 					sx={{mt: 5}}
 				/>

--- a/src/routes/(home)/athlons/[id]/[ruleId]/edit.tsx
+++ b/src/routes/(home)/athlons/[id]/[ruleId]/edit.tsx
@@ -57,12 +57,12 @@ const AthlonEdit = () => {
 				console.error(`Invalid userId: ${userId}`);
 				return;
 			}
-			const rawScore = parseFloat(rawScoreText);
+			const rawScore = Number.parseFloat(rawScoreText);
 			if (!Number.isFinite(rawScore)) {
 				console.error(`Invalid rawScore: ${rawScoreText}`);
 				return;
 			}
-			const tiebreakScore = parseFloat(tiebreakScoreText);
+			const tiebreakScore = Number.parseFloat(tiebreakScoreText);
 			if (!Number.isFinite(tiebreakScore)) {
 				console.error(`Invalid tiebreakScore: ${tiebreakScoreText}`);
 				return;

--- a/src/routes/(home)/athlons/[id]/[ruleId]/index.tsx
+++ b/src/routes/(home)/athlons/[id]/[ruleId]/index.tsx
@@ -98,7 +98,7 @@ const ScoreRecordDialog = (props: Props) => {
 									value={dayjs(tiebreakScore() || 0).format('HH:mm:ss')}
 									onChange={(event) => {
 										const time = event.currentTarget.value;
-										const [hours, minutes, seconds] = time.split(':').map((component) => parseInt(component));
+										const [hours, minutes, seconds] = time.split(':').map((component) => Number.parseInt(component));
 										const timeData = dayjs().set('hours', hours).set('minutes', minutes).set('seconds', seconds);
 
 										setTiebreakScore(timeData.valueOf());
@@ -116,7 +116,7 @@ const ScoreRecordDialog = (props: Props) => {
 								required
 								value={score()}
 								onChange={(event, value) => {
-									setScore(parseInt(value));
+									setScore(Number.parseInt(value));
 									setTiebreakScore(0);
 								}}
 							/>

--- a/src/routes/(home)/athlons/[id]/leaderboard.tsx
+++ b/src/routes/(home)/athlons/[id]/leaderboard.tsx
@@ -20,8 +20,8 @@ const transpose = <T, >(array: T[][]): T[][] => (
 );
 
 const isUserIdNewerThanOrEqualTo = (userId: string, thresholdUserId: string) => {
-	const userIdNumber = parseInt(userId.slice(1), 36);
-	const thresholdUserIdNumber = parseInt(thresholdUserId.slice(1), 36);
+	const userIdNumber = Number.parseInt(userId.slice(1), 36);
+	const thresholdUserIdNumber = Number.parseInt(thresholdUserId.slice(1), 36);
 
 	return userIdNumber >= thresholdUserIdNumber;
 };

--- a/src/routes/(home)/athlons/index.tsx
+++ b/src/routes/(home)/athlons/index.tsx
@@ -77,7 +77,7 @@ const Athlons = () => {
 															{(rank, j) => (
 																<Stack direction="row" px={1}>
 																	<Show when={j() === 0}>
-																		<img src="/images/crown-solid.svg" style={{width: '36px'}}/>
+																		<img src="/images/crown-solid.svg" style={{width: '36px'}} alt=""/>
 																	</Show>
 																	<Show when={j() > 0}>
 																		<div class={styles.rank}>{j() + 1}</div>

--- a/src/routes/(home)/settings.tsx
+++ b/src/routes/(home)/settings.tsx
@@ -127,7 +127,7 @@ const Settings = () => {
 								<Typography variant="caption">
 									Icon
 								</Typography>
-								<img src={photoURL()} style={{width: '10rem', height: '10rem', 'object-fit': 'contain'}}/>
+								<img src={photoURL()} style={{width: '10rem', height: '10rem', 'object-fit': 'contain'}} alt="Icon preview"/>
 								<Button variant="contained" component="label">
 									<span>Select File</span>
 									<input

--- a/src/routes/arenas/esolang.tsx
+++ b/src/routes/arenas/esolang.tsx
@@ -104,7 +104,7 @@ const getBytes = (code: unknown): Uint8Array => {
 const bytesToBase64 = (bytes: Uint8Array): string => {
 	let binary = '';
 	for (const byte of bytes) {
-		binary += String.fromCharCode(byte);
+		binary += String.fromCodePoint(byte);
 	}
 	return btoa(binary);
 };
@@ -113,7 +113,7 @@ const base64ToBytes = (base64: string): Uint8Array => {
 	const binary = atob(base64);
 	const bytes = new Uint8Array(binary.length);
 	for (let i = 0; i < binary.length; i++) {
-		bytes[i] = binary.charCodeAt(i);
+		bytes[i] = binary.codePointAt(i) ?? 0;
 	}
 	return bytes;
 };

--- a/src/routes/arenas/typing-japanese.tsx
+++ b/src/routes/arenas/typing-japanese.tsx
@@ -174,7 +174,7 @@ const TypingJapanese = () => {
 			setPhase('waiting');
 
 			const startTimeString = localStorage.getItem(`typing-japanese_${gameId}_startTime`);
-			const startTime = startTimeString ? parseFloat(startTimeString) : null;
+			const startTime = startTimeString ? Number.parseFloat(startTimeString) : null;
 			if (savedConfig.enabled && startTime !== null) {
 				setPhase('playing');
 			}
@@ -265,6 +265,7 @@ const TypingJapanese = () => {
 
 			{/* eslint-disable-next-line react/iframe-missing-sandbox -- https://github.com/whatwg/html/issues/3958 */}
 			<iframe
+				title="Typing text PDF"
 				class={styles.pdf}
 				style={{visibility: phase() === 'playing' || phase() === 'finished' ? 'visible' : 'hidden'}}
 				src={`${pdfUrl()}#${new URLSearchParams({


### PR DESCRIPTION
## Summary

SonarQubeで検出されたissueのうち、低リスク・機能変更なしで修正できるものを一括対応。

- `parseInt`/`parseFloat` → `Number.parseInt`/`Number.parseFloat` に統一（8箇所）
  - `functions/src/executions.ts` (3箇所)
  - `src/routes/(home)/athlons/[id]/leaderboard.tsx` (2箇所)
  - `src/routes/(home)/athlons/[id]/[ruleId]/edit.tsx` (2箇所)
  - `src/routes/(home)/athlons/[id]/[ruleId]/index.tsx` (2箇所)
  - `src/routes/arenas/typing-japanese.tsx` (2箇所)
- `img` 要素に `alt` 属性を追加（アクセシビリティ対応、4ファイル）
- `iframe` に `title` 属性を追加（`typing-japanese.tsx`）
- `String.fromCharCode` → `String.fromCodePoint`、`charCodeAt` → `codePointAt` に置換（`esolang.tsx`）
- 固定パターンの `\r\n` regex を文字列リテラルに変更（`executions.ts`）

## Test plan

- [x] `npm run lint` — auto-fix 後に新規エラーなし
- [x] `npx tsc --noEmit` — エラーなし（frontend・functions 両方）
- [x] `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)