### PR TITLE
refactor(functions): reduce cognitive complexity in onSubmissionCreated

### DIFF
--- a/functions/src/submissions.ts
+++ b/functions/src/submissions.ts
@@ -1,5 +1,5 @@
 import assert, {AssertionError} from 'node:assert';
-import type {DocumentReference} from 'firebase-admin/firestore';
+import type {DocumentReference, DocumentSnapshot} from 'firebase-admin/firestore';
 import {Queue} from 'bullmq';
 import {onDocumentCreated} from 'firebase-functions/firestore';
 import {info as logInfo, warn as logWarn} from 'firebase-functions/logger';
@@ -76,6 +76,56 @@ const isAdjacentToAcquired = (cellIndex: number, acquiredCells: Set<number>): bo
 		}
 	}
 	return false;
+};
+
+const buildEsolangJobData = async ({
+	changedGameId,
+	changedSubmissionId,
+	snapshot,
+	config,
+	submissionRef,
+}: {
+	changedGameId: string;
+	changedSubmissionId: string;
+	snapshot: DocumentSnapshot;
+	config: EsolangConfiguration;
+	submissionRef: ReturnType<typeof db.doc>;
+}): Promise<DecathlonJobData | null> => {
+	const submission = snapshot.data() as EsolangSubmission;
+	const cellConfig = config.languages[submission.languageIndex];
+	if (!cellConfig || cellConfig.type !== 'language') {
+		await submissionRef.update({status: 'invalid', errorMessage: 'Invalid cell: not a language cell'});
+		return null;
+	}
+	if (cellConfig.id !== submission.languageId) {
+		await submissionRef.update({status: 'invalid', errorMessage: 'Language ID mismatch'});
+		return null;
+	}
+	const rankingRef = db.doc(`games/${changedGameId}/ranking/${submission.userId}`) as DocumentReference<EsolangRanking>;
+	const rankingDoc = await rankingRef.get();
+	const rankingData = rankingDoc.data();
+	const acquiredCells = new Set<number>();
+	for (let i = 0; i < config.languages.length; i++) {
+		if (config.languages[i]?.type === 'base') {
+			acquiredCells.add(i);
+		}
+	}
+	for (const cell of rankingData?.acquiredCells ?? []) {
+		acquiredCells.add(cell);
+	}
+	if (!isAdjacentToAcquired(submission.languageIndex, acquiredCells)) {
+		await submissionRef.update({status: 'invalid', errorMessage: 'Cell is not adjacent to any acquired cell'});
+		return null;
+	}
+	return {
+		gameId: changedGameId,
+		submissionId: changedSubmissionId,
+		imageId: `esolang/${submission.languageId}`,
+		code: toBuffer(submission.code).toString('base64'),
+		codeEncoding: 'base64',
+		testcases: config.testcases.map((tc) => ({stdin: tc.input})),
+		timeoutMs: 50000,
+	};
 };
 
 // --- Trigger 1: enqueue BullMQ job on new submission ---
@@ -173,50 +223,13 @@ export const onSubmissionCreated = onDocumentCreated(
 		}
 
 		if (game.rule.path === 'gameRules/esolang') {
-			const submission = snapshot.data() as EsolangSubmission;
-			const config = game.configuration as EsolangConfiguration;
-
-			const cellConfig = config.languages[submission.languageIndex];
-			if (!cellConfig || cellConfig.type !== 'language') {
-				await submissionRef.update({status: 'invalid', errorMessage: 'Invalid cell: not a language cell'});
-				return;
-			}
-
-			if (cellConfig.id !== submission.languageId) {
-				await submissionRef.update({status: 'invalid', errorMessage: 'Language ID mismatch'});
-				return;
-			}
-
-			const rankingRef = db.doc(`games/${changedGameId}/ranking/${submission.userId}`) as DocumentReference<EsolangRanking>;
-			const rankingDoc = await rankingRef.get();
-			const rankingData = rankingDoc.data();
-
-			const acquiredCells = new Set<number>();
-			for (let i = 0; i < config.languages.length; i++) {
-				if (config.languages[i]?.type === 'base') {
-					acquiredCells.add(i);
-				}
-			}
-			for (const cell of rankingData?.acquiredCells ?? []) {
-				acquiredCells.add(cell);
-			}
-
-			const isAdjacent = isAdjacentToAcquired(submission.languageIndex, acquiredCells);
-
-			if (!isAdjacent) {
-				await submissionRef.update({status: 'invalid', errorMessage: 'Cell is not adjacent to any acquired cell'});
-				return;
-			}
-
-			jobData = {
-				gameId: changedGameId,
-				submissionId: changedSubmissionId,
-				imageId: `esolang/${submission.languageId}`,
-				code: toBuffer(submission.code).toString('base64'),
-				codeEncoding: 'base64',
-				testcases: config.testcases.map((tc) => ({stdin: tc.input})),
-				timeoutMs: 50000,
-			};
+			jobData = await buildEsolangJobData({
+				changedGameId,
+				changedSubmissionId,
+				snapshot,
+				config: game.configuration as EsolangConfiguration,
+				submissionRef,
+			});
 		}
 
 		if (jobData) {


### PR DESCRIPTION
## Summary

- Extracts esolang submission handling from `onSubmissionCreated` into a dedicated `buildEsolangJobData` helper function
- Reduces `onSubmissionCreated`'s cognitive complexity from 23 to ~12, resolving SonarQube S3776 (threshold: 15)
- Also adds `DocumentSnapshot` to imports for proper typing

## SonarQube issue fixed

- `typescript:S3776` in `functions/src/submissions.ts:85` — "Refactor this function to reduce its Cognitive Complexity from 23 to the 15 allowed"

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` introduces no new warnings
- [x] `npm run build` succeeds
- [x] Logic is unchanged: `buildEsolangJobData` returns `null` (after updating status to `invalid`) for validation failures, or the job data object on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)