### PR TITLE
feat: add reference records for athlons

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -331,6 +331,19 @@ service cloud.firestore {
         && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
     }
 
+    match /athlons/{athlonId}/referenceRecords/{recordId} {
+      allow read;
+      allow create, update: if isGlobalAdmin()
+                            && request.resource.data.keys().hasOnly(['name', 'description', 'athlonId', 'scores', 'createdAt', 'updatedAt'])
+                            && request.resource.data.name is string
+                            && request.resource.data.name.size() > 0
+                            && request.resource.data.description is string
+                            && request.resource.data.athlonId is string
+                            && request.resource.data.scores is map
+                            && request.resource.data.updatedAt == request.time;
+      allow delete: if isGlobalAdmin();
+    }
+
     match /rules/{ruleId} {
       allow read;
       allow create: if isGlobalAdmin()

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,9 +10,9 @@ import {info as logInfo, error as logError} from 'firebase-functions/logger';
 import {defineString} from 'firebase-functions/params';
 import {user as authUser} from 'firebase-functions/v1/auth';
 import {Diff} from 'mdiff';
-import type {Athlon, Game, PromptEngineeringVote, Score, TypingJapaneseSubmission, SlackUserInfo, AthlonRanking} from '~/lib/schema.js';
+import type {Athlon, Game, PromptEngineeringVote, ReferenceRecord, Score, TypingJapaneseSubmission, SlackUserInfo, AthlonRanking} from '~/lib/schema.js';
 import {db} from './firebase.js';
-import {calculateRanking, updatePromptEngineeringScores} from './scores.js';
+import {calculateRanking, calculateReferenceRecordRankings, updatePromptEngineeringScores} from './scores.js';
 
 export * from './submissions.js';
 export * from './executions.js';
@@ -95,6 +95,9 @@ export const onRankingWritten = onDocumentWritten(
 	'athlons/{athlonId}/rankings/{userId}',
 	async (event) => {
 		const {userId} = event.params;
+		if (userId.startsWith('ref_')) {
+			return;
+		}
 		const existed = event.data?.before?.exists ?? false;
 		const exists = event.data?.after?.exists ?? false;
 
@@ -145,12 +148,23 @@ export const onScoreChanged = onDocumentWritten(
 
 			const ranking = calculateRanking(gameDocs, scoreDocs);
 
+			const referenceRecordsRef = athlon.collection('referenceRecords') as CollectionReference<ReferenceRecord>;
+			const referenceRecordsDocs = await transaction.get(referenceRecordsRef);
+			const referenceRecords = referenceRecordsDocs.docs.map((d) => ({id: d.id, data: d.data()}));
+			const refRankings = calculateReferenceRecordRankings(referenceRecords, gameDocs, scoreDocs, ranking);
+
 			const athlonRankings = athlon.collection('rankings') as CollectionReference<AthlonRanking>;
 			const existingRankings = await transaction.get(athlonRankings);
 
 			const newUserIds = new Set(ranking.map((entry) => entry.userId));
+			const newRefIds = new Set(refRankings.map((r) => `ref_${r.referenceRecordId}`));
 			for (const existingEntry of existingRankings.docs) {
-				if (!newUserIds.has(existingEntry.id)) {
+				const docId = existingEntry.id;
+				if (docId.startsWith('ref_')) {
+					if (!newRefIds.has(docId)) {
+						transaction.delete(existingEntry.ref);
+					}
+				} else if (!newUserIds.has(docId)) {
 					transaction.delete(existingEntry.ref);
 				}
 			}
@@ -159,6 +173,51 @@ export const onScoreChanged = onDocumentWritten(
 				const {userId} = rankingEntry;
 				const rankingEntryRef = athlonRankings.doc(userId);
 				transaction.set(rankingEntryRef, {...rankingEntry, athlonId: athlon.id});
+			}
+
+			for (const refRanking of refRankings) {
+				const refRankingRef = athlonRankings.doc(`ref_${refRanking.referenceRecordId}`);
+				transaction.set(refRankingRef, refRanking);
+			}
+		});
+	},
+);
+
+export const onReferenceRecordWritten = onDocumentWritten(
+	'athlons/{athlonId}/referenceRecords/{recordId}',
+	async (event) => {
+		const {athlonId, recordId} = event.params;
+		const athlonRankings = db.collection('athlons').doc(athlonId).collection('rankings') as CollectionReference<AthlonRanking>;
+		const refRankingRef = athlonRankings.doc(`ref_${recordId}`);
+
+		const afterData = event.data?.after?.data() as ReferenceRecord | undefined;
+		if (!afterData) {
+			await refRankingRef.delete();
+			return;
+		}
+
+		const athlonRef = db.collection('athlons').doc(athlonId) as DocumentReference<Athlon>;
+		await db.runTransaction(async (transaction) => {
+			const gameDocs = await transaction.get(
+				(db.collection('games') as CollectionReference<Game>)
+					.where('athlon', '==', athlonRef)
+					.orderBy('order', 'asc'),
+			);
+			const scoreDocs = await transaction.get(
+				(db.collectionGroup('scores') as CollectionGroup<Score>)
+					.where('athlon', '==', athlonRef),
+			);
+
+			const userRanking = calculateRanking(gameDocs, scoreDocs);
+			const refRankings = calculateReferenceRecordRankings(
+				[{id: recordId, data: afterData}],
+				gameDocs,
+				scoreDocs,
+				userRanking,
+			);
+
+			if (refRankings.length > 0) {
+				transaction.set(refRankingRef, refRankings[0]);
 			}
 		});
 	},

--- a/functions/src/scores.ts
+++ b/functions/src/scores.ts
@@ -3,9 +3,9 @@
 
 import type {CollectionReference, DocumentReference, DocumentSnapshot, QuerySnapshot} from 'firebase-admin/firestore';
 import {prop, sortBy, sum} from 'remeda';
-import type {Game, PromptEngineeringResult, PromptEngineeringSubmission, PromptEngineeringVote, Score} from '~/lib/schema.js';
+import type {Game, PromptEngineeringResult, PromptEngineeringSubmission, PromptEngineeringVote, ReferenceRecord, Score} from '~/lib/schema.js';
 import {db} from './firebase.js';
-import {RankedScore, calculateGameRanking} from './lib/scores.js';
+import {RankedScore, calculateGameRanking, calculateReferenceScore} from './lib/scores.js';
 
 export const calculateRanking = (gameDocs: QuerySnapshot<Game>, scoreDocs: QuerySnapshot<Score>) => {
 	const usersSet = new Set<string>();
@@ -109,6 +109,78 @@ export const calculateRanking = (gameDocs: QuerySnapshot<Game>, scoreDocs: Query
 	});
 
 	return ranking;
+};
+
+export const calculateReferenceRecordRankings = (
+	referenceRecords: {id: string, data: ReferenceRecord}[],
+	gameDocs: QuerySnapshot<Game>,
+	scoreDocs: QuerySnapshot<Score>,
+	userRanking: ReturnType<typeof calculateRanking>,
+) => {
+	const scoresMap = new Map<string, Score[]>();
+	for (const score of scoreDocs.docs) {
+		const gameId = score.ref.parent.parent?.id!;
+		if (!scoresMap.has(gameId)) {
+			scoresMap.set(gameId, []);
+		}
+		scoresMap.get(gameId)!.push(score.data());
+	}
+
+	const gamesMap = new Map<string, Game>();
+	for (const game of gameDocs.docs) {
+		gamesMap.set(game.id, game.data());
+	}
+
+	const gameRealScores = new Map<string, RankedScore[]>();
+	const gameRealMaxRawScore = new Map<string, number>();
+	for (const gameDoc of gameDocs.docs) {
+		const scores = scoresMap.get(gameDoc.id) ?? [];
+		const ranked = calculateGameRanking(gameDoc.data(), scores);
+		const realScores = ranked.filter((s) => !s.isAuthor);
+		gameRealScores.set(gameDoc.id, realScores);
+		gameRealMaxRawScore.set(
+			gameDoc.id,
+			realScores.length > 0 ? Math.max(...realScores.map((s) => s.rawScore)) : 0,
+		);
+	}
+
+	return referenceRecords.map(({id: recordId, data: record}) => {
+		const games = gameDocs.docs.map((gameDoc) => {
+			const gameId = gameDoc.id;
+			const game = gameDoc.data();
+			const refScore = record.scores[gameId];
+
+			if (!refScore) {
+				return {gameId, hasScore: false, isAuthor: false, point: 0, rawScore: 0, tiebreakScore: 0, rank: null};
+			}
+
+			const realScores = gameRealScores.get(gameId) ?? [];
+			const realMaxRawScore = gameRealMaxRawScore.get(gameId) ?? 0;
+
+			const rank = realScores.filter((s) => {
+				if (s.rawScore > refScore.rawScore) {
+					return true;
+				}
+				if (s.rawScore === refScore.rawScore) {
+					return game.tiebreakOrder === 'asc'
+						? s.tiebreakScore < refScore.tiebreakScore
+						: s.tiebreakScore > refScore.tiebreakScore;
+				}
+				return false;
+			}).length;
+
+			const point = calculateReferenceScore(
+				refScore.rawScore, rank, game.maxPoint, game.scoreConfiguration, realMaxRawScore,
+			);
+
+			return {gameId, hasScore: true, isAuthor: false, point, rawScore: refScore.rawScore, tiebreakScore: refScore.tiebreakScore, rank};
+		});
+
+		const pointSum = sum(games.map(({gameId, point}) => point * (gamesMap.get(gameId)?.weight ?? 1)));
+		const rank = userRanking.filter((u) => u.point > pointSum).length;
+
+		return {userId: '', referenceRecordId: recordId, athlonId: record.athlonId, point: pointSum, rank, games};
+	});
 };
 
 export const updatePromptEngineeringScores = async (game: DocumentSnapshot<Game>) => {

--- a/lib/scores.ts
+++ b/lib/scores.ts
@@ -58,6 +58,24 @@ export const calculateScore = (
 	return scorePoint + rankPoint;
 };
 
+// Like calculateScore but for reference records: for max-ratio, realMaxRawScore is
+// computed from real users only, so ref scores above that cap at maxPoint.
+export const calculateReferenceScore = (
+	rawScore: number,
+	rank: number,
+	maxPoint: number,
+	configuration: ScoreConfiguration,
+	realMaxRawScore: number,
+) => {
+	if (configuration.type === 'max-ratio') {
+		if (realMaxRawScore === 0) {
+			return rawScore > 0 ? maxPoint : 0;
+		}
+		return Math.min(maxPoint, rawScore / realMaxRawScore * maxPoint);
+	}
+	return calculateScore(rawScore, rank, maxPoint, configuration);
+};
+
 export interface RankedScore extends Score {
 	rank: number,
 	point: number,

--- a/src/lib/schema.d.ts
+++ b/src/lib/schema.d.ts
@@ -15,6 +15,7 @@ export type SlackUserInfo = SlackUser
 
 export interface RankingEntry {
 	userId: string,
+	referenceRecordId?: string,
 	athlonId: string,
 	point: number,
 	rank: number,
@@ -27,6 +28,21 @@ export interface RankingEntry {
 		tiebreakScore: number,
 		rank: number | null,
 	}[],
+}
+
+export interface ReferenceRecordGameScore {
+	rawScore: number,
+	tiebreakScore: number,
+	description: string,
+}
+
+export interface ReferenceRecord extends DocumentData {
+	name: string,
+	description: string,
+	athlonId: string,
+	scores: Record<string, ReferenceRecordGameScore>,
+	createdAt: Timestamp,
+	updatedAt: Timestamp,
 }
 
 export interface Athlon {

--- a/src/routes/(home)/athlons/[id]/[ruleId]/leaderboard.tsx
+++ b/src/routes/(home)/athlons/[id]/[ruleId]/leaderboard.tsx
@@ -1,17 +1,17 @@
 import {A, useParams} from '@solidjs/router';
 import {Typography, Container, Breadcrumbs, Link, TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, Stack, Chip} from '@suid/material';
-import {blue} from '@suid/material/colors';
+import {blue, grey} from '@suid/material/colors';
 import {getAuth} from 'firebase/auth';
 import {collection, CollectionReference, doc, DocumentReference, getFirestore, query, where} from 'firebase/firestore';
 import {floor} from 'remeda';
 import {useAuth, useFirebaseApp, useFirestore} from 'solid-firebase';
-import {For, Show} from 'solid-js';
+import {createMemo, For, Show} from 'solid-js';
 import {calculateGameRanking} from '~/../lib/scores';
 import Collection from '~/components/Collection';
 import Doc from '~/components/Doc';
 import PageTitle from '~/components/PageTitle';
 import Username from '~/components/Username';
-import type {Game, GameRule, Score} from '~/lib/schema';
+import type {Game, GameRule, RankingEntry, ReferenceRecord, Score} from '~/lib/schema';
 import useAthlon from '~/lib/useAthlon';
 
 const Leaderboard = () => {
@@ -30,6 +30,12 @@ const Leaderboard = () => {
 			where('athlon', '==', doc(db, 'athlons', param.id)),
 			where('rule', '==', ruleRef),
 		),
+	);
+	const athlonRankingsData = useFirestore(
+		collection(db, 'athlons', param.id, 'rankings') as CollectionReference<RankingEntry>,
+	);
+	const referenceRecordsData = useFirestore(
+		collection(db, 'athlons', param.id, 'referenceRecords') as CollectionReference<ReferenceRecord>,
 	);
 	const authState = useAuth(auth);
 
@@ -110,45 +116,96 @@ const Leaderboard = () => {
 													const rankedScores = calculateGameRanking(game, scores);
 													const hasDecimalRawScore = scores.some((score) => !Number.isInteger(score.rawScore));
 
-													return (
-														<For each={rankedScores}>
-															{(score) => {
-																const isMe = authState?.data?.uid === score.id;
+													const isGameEnded = createMemo(() => {
+														if (!game.endAt) {
+															return false;
+														}
+														return game.endAt.toDate() < new Date();
+													});
 
-																return (
-																	<TableRow sx={isMe ? {backgroundColor: blue[50]} : {}}>
+													const refEntries = createMemo(() => {
+														if (!isGameEnded()) {
+															return [];
+														}
+														const rankings = athlonRankingsData.data ?? [];
+														const refRecords = referenceRecordsData.data ?? [];
+														return rankings
+															.filter((r) => r.referenceRecordId)
+															.map((r) => {
+																const gameEntry = r.games.find((g) => g.gameId === game.id);
+																const record = refRecords.find((rec) => rec.id === r.referenceRecordId);
+																return {ranking: r, gameEntry, record};
+															})
+															.filter(({gameEntry}) => gameEntry?.hasScore);
+													});
+
+													return (
+														<>
+															<For each={rankedScores}>
+																{(score) => {
+																	const isMe = authState?.data?.uid === score.id;
+
+																	return (
+																		<TableRow sx={isMe ? {backgroundColor: blue[50]} : {}}>
+																			<TableCell>
+																				<Show when={!score.isAuthor}>
+																					{score.rank + 1}
+																				</Show>
+																			</TableCell>
+																			<TableCell>
+																				<Stack direction="row">
+																					<Username userId={score.user}/>
+																					<Show when={score.isAuthor}>
+																						<Chip label="author" color="primary" variant="outlined" sx={{ml: 1}}/>
+																					</Show>
+																				</Stack>
+																			</TableCell>
+																			<TableCell align="right">
+																				<Show when={!score.isAuthor}>
+																					{hasDecimalRawScore ? floor(score.rawScore, 2).toFixed(2) : score.rawScore}
+																				</Show>
+																			</TableCell>
+																			<TableCell align="right">
+																				<Show when={!score.isAuthor}>
+																					{score.tiebreakScore}
+																				</Show>
+																			</TableCell>
+																			<TableCell align="right">
+																				<strong>
+																					{floor(score.point, 2).toFixed(2)}
+																				</strong>
+																			</TableCell>
+																		</TableRow>
+																	);
+																}}
+															</For>
+															<For each={refEntries()}>
+																{({ranking, gameEntry, record}) => (
+																	<TableRow sx={{backgroundColor: grey[100]}}>
 																		<TableCell>
-																			<Show when={!score.isAuthor}>
-																				{score.rank + 1}
-																			</Show>
+																			{gameEntry?.rank !== null && gameEntry?.rank !== undefined ? gameEntry.rank + 1 : ''}
 																		</TableCell>
 																		<TableCell>
-																			<Stack direction="row">
-																				<Username userId={score.user}/>
-																				<Show when={score.isAuthor}>
-																					<Chip label="author" color="primary" variant="outlined" sx={{ml: 1}}/>
-																				</Show>
+																			<Stack direction="row" alignItems="center" gap={1}>
+																				<span>{record?.name ?? ranking.referenceRecordId}</span>
+																				<Chip label="参考" size="small" variant="outlined" color="default"/>
 																			</Stack>
 																		</TableCell>
 																		<TableCell align="right">
-																			<Show when={!score.isAuthor}>
-																				{hasDecimalRawScore ? floor(score.rawScore, 2).toFixed(2) : score.rawScore}
-																			</Show>
+																			{gameEntry?.rawScore ?? ''}
 																		</TableCell>
 																		<TableCell align="right">
-																			<Show when={!score.isAuthor}>
-																				{score.tiebreakScore}
-																			</Show>
+																			{gameEntry?.tiebreakScore ?? ''}
 																		</TableCell>
 																		<TableCell align="right">
 																			<strong>
-																				{floor(score.point, 2).toFixed(2)}
+																				{floor(gameEntry?.point ?? 0, 2).toFixed(2)}
 																			</strong>
 																		</TableCell>
 																	</TableRow>
-																);
-															}}
-														</For>
+																)}
+															</For>
+														</>
 													);
 												}}
 											</Show>

--- a/src/routes/(home)/athlons/[id]/index.tsx
+++ b/src/routes/(home)/athlons/[id]/index.tsx
@@ -119,7 +119,7 @@ const Home = () => {
 				</Head>
 				<Doc data={athlonRankingsData}>
 					{(athlonRankings) => (
-						<RankingSummary users={athlonRankings.map((rank) => rank.userId)}/>
+						<RankingSummary users={athlonRankings.filter((r) => !r.referenceRecordId).map((rank) => rank.userId)}/>
 					)}
 				</Doc>
 				<Box textAlign="center" my={3}>

--- a/src/routes/(home)/athlons/[id]/leaderboard.tsx
+++ b/src/routes/(home)/athlons/[id]/leaderboard.tsx
@@ -1,7 +1,7 @@
 import {A, useParams, useSearchParams} from '@solidjs/router';
 import {ElectricBolt, Star} from '@suid/icons-material';
-import {Typography, Container, Breadcrumbs, Link, TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, Stack, FormControlLabel, Switch as SwitchControl, Box, ButtonGroup, Button} from '@suid/material';
-import {blue, orange, red, yellow} from '@suid/material/colors';
+import {Chip, Typography, Container, Breadcrumbs, Link, TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, Stack, FormControlLabel, Switch as SwitchControl, Box, ButtonGroup, Button} from '@suid/material';
+import {blue, grey, orange, red, yellow} from '@suid/material/colors';
 import dayjs from 'dayjs';
 import {getAuth} from 'firebase/auth';
 import {collection, CollectionReference, doc, getFirestore, orderBy, query, where} from 'firebase/firestore';
@@ -12,7 +12,7 @@ import Collection from '~/components/Collection';
 import Doc from '~/components/Doc';
 import PageTitle from '~/components/PageTitle';
 import Username from '~/components/Username';
-import type {Game, RankingEntry, User} from '~/lib/schema';
+import type {Game, RankingEntry, ReferenceRecord, User} from '~/lib/schema';
 import useAthlon from '~/lib/useAthlon';
 
 const transpose = <T, >(array: T[][]): T[][] => (
@@ -32,6 +32,8 @@ interface RankingTableProps {
 	rookieThresholdId: string | null,
 	thresholdId: string | null,
 	showRawScore: boolean,
+	referenceRecords: ReferenceRecord[],
+	isAthlonEnded: boolean,
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Type compatibility with useParams
@@ -59,39 +61,47 @@ const RankingTable = (props: RankingTableProps) => {
 	);
 
 	const ranking = createMemo<(RankingEntry & {originalRank?: number})[]>(() => {
+		const allRanking = [...props.ranking].sort((a, b) => b.point - a.point);
 		const thresholdId = props.thresholdId;
-		if (!thresholdId) {
-			return props.ranking;
+
+		if (thresholdId) {
+			const usersInfoData = usersData.data;
+			if (!usersInfoData) {
+				return allRanking.filter((r) => !r.referenceRecordId);
+			}
+
+			let rankCounter = 0;
+			return allRanking
+				.filter((user) => {
+					if (user.referenceRecordId) {
+						return false;
+					}
+					const userInfo = usersInfoData.find((u) => u.id === user.userId);
+					if (!userInfo) {
+						return false;
+					}
+					return isUserIdNewerThanOrEqualTo(userInfo.slackId, thresholdId);
+				})
+				.map((user) => {
+					const newRank = rankCounter;
+					rankCounter++;
+					return {
+						...user,
+						rank: newRank,
+						originalRank: user.rank,
+					};
+				});
 		}
 
-		const usersInfoData = usersData.data;
-		if (!usersInfoData) {
-			return props.ranking;
+		if (!props.isAthlonEnded) {
+			return allRanking.filter((r) => !r.referenceRecordId);
 		}
-
-		let rankCounter = 0;
-		return props.ranking
-			.filter((user) => {
-				const userInfo = usersInfoData.find((u) => u.id === user.userId);
-				if (!userInfo) {
-					return false;
-				}
-				return isUserIdNewerThanOrEqualTo(userInfo.slackId, thresholdId);
-			})
-			.map((user) => {
-				const newRank = rankCounter;
-				rankCounter++;
-				return {
-					...user,
-					rank: newRank,
-					originalRank: user.rank,
-				};
-			});
+		return allRanking;
 	});
 
 	const participants = createMemo(() => (
 		transpose(
-			ranking().map((user) => (
+			ranking().filter((r) => !r.referenceRecordId).map((user) => (
 				user.games.map((game) => game.hasScore && game.point > 0 && !game.isAuthor)
 			)),
 		).map((users) => filter(users, (user) => user === true).length)
@@ -132,10 +142,11 @@ const RankingTable = (props: RankingTableProps) => {
 				<TableBody>
 					<For each={ranking()}>
 						{(userEntry) => {
-							const isMe = authState?.data?.uid === userEntry.userId;
+							const isRef = () => Boolean(userEntry.referenceRecordId);
+							const isMe = !isRef() && authState?.data?.uid === userEntry.userId;
 
 							const isRookie = createMemo(() => {
-								if (!props.rookieThresholdId) {
+								if (isRef() || !props.rookieThresholdId) {
 									return false;
 								}
 
@@ -146,8 +157,24 @@ const RankingTable = (props: RankingTableProps) => {
 								return isUserIdNewerThanOrEqualTo(userInfo.slackId, props.rookieThresholdId);
 							});
 
+							const refName = createMemo(() => {
+								if (!userEntry.referenceRecordId) {
+									return null;
+								}
+								return props.referenceRecords.find((r) => r.id === userEntry.referenceRecordId)?.name ?? userEntry.referenceRecordId;
+							});
+
+							const getRowBg = () => {
+								if (isRef()) {
+									return grey[100];
+								}
+								if (isMe) {
+									return blue[50];
+								}
+								return undefined;
+							};
 							return (
-								<TableRow sx={isMe ? {backgroundColor: blue[50]} : {}}>
+								<TableRow sx={getRowBg() !== undefined ? {backgroundColor: getRowBg()} : {}}>
 									<TableCell>
 										<strong>
 											{userEntry.rank + 1}
@@ -161,10 +188,20 @@ const RankingTable = (props: RankingTableProps) => {
 										</Show>
 									</TableCell>
 									<TableCell>
-										<Stack direction="row" alignItems="center">
-											<Username userId={userEntry.userId}/>
-											<Show when={isRookie()} >
-												🔰
+										<Stack direction="row" alignItems="center" gap={1}>
+											<Show
+												when={isRef()}
+												fallback={
+													<Stack direction="row" alignItems="center">
+														<Username userId={userEntry.userId}/>
+														<Show when={isRookie()}>
+															🔰
+														</Show>
+													</Stack>
+												}
+											>
+												<span>{refName()}</span>
+												<Chip label="参考" size="small" variant="outlined" color="default"/>
 											</Show>
 										</Stack>
 									</TableCell>
@@ -258,6 +295,9 @@ const Leaderboard = () => {
 			collection(db, 'athlons', param.id, 'rankings') as CollectionReference<RankingEntry>,
 			orderBy('rank'),
 		),
+	);
+	const referenceRecordsData = useFirestore(
+		collection(db, 'athlons', param.id, 'referenceRecords') as CollectionReference<ReferenceRecord>,
 	);
 
 	const [showRawScore, setShowRawScore] = createSignal<boolean>(false);
@@ -361,6 +401,8 @@ const Leaderboard = () => {
 									rookieThresholdId={athlon.rookieThresholdId}
 									thresholdId={searchParams.mode === 'rookie' ? athlon.rookieThresholdId : null}
 									showRawScore={showRawScore()}
+									referenceRecords={referenceRecordsData.data ?? []}
+									isAthlonEnded={isEnded() === true}
 								/>
 							)}
 						</Doc>

--- a/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/index.tsx
+++ b/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/index.tsx
@@ -1,0 +1,218 @@
+import {A, Navigate, useParams} from '@solidjs/router';
+import {Breadcrumbs, Button, Container, Divider, Link, Stack, TextField, Typography} from '@suid/material';
+import {getAuth} from 'firebase/auth';
+import {addDoc, collection, CollectionReference, doc, DocumentReference, getFirestore, orderBy, query, serverTimestamp, setDoc, where} from 'firebase/firestore';
+import {useAuth, useFirebaseApp, useFirestore} from 'solid-firebase';
+import {createEffect, createMemo, createSignal, Show} from 'solid-js';
+import Collection from '~/components/Collection';
+import Doc from '~/components/Doc';
+import PageTitle from '~/components/PageTitle';
+import type {Game, GameRule, ReferenceRecord, UseFireStoreReturn, User} from '~/lib/schema';
+import useAthlon from '~/lib/useAthlon';
+
+const ReferenceRecordEdit = () => {
+	const param = useParams<{id: string, recordId: string}>();
+	const isNew = () => param.recordId === 'new';
+	const app = useFirebaseApp();
+	const db = getFirestore(app);
+	const auth = getAuth(app);
+	const authState = useAuth(auth);
+	const athlonData = useAthlon(param.id);
+
+	const [userData, setUserData] = createSignal<UseFireStoreReturn<User | null | undefined> | null>(null);
+	createEffect(() => {
+		if (authState.data) {
+			const userRef = doc(db, 'users', authState.data.uid) as DocumentReference<User>;
+			setUserData(useFirestore(userRef));
+		}
+	});
+
+	const isAdmin = createMemo(() => userData()?.data?.isAdmin === true);
+	const notAdmin = createMemo(() => (
+		!authState.loading &&
+		(userData() !== null) &&
+		!isAdmin()
+	));
+
+	const existingRecordData = useFirestore(
+		doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
+	);
+
+	const gamesData = useFirestore(
+		query(
+			collection(db, 'games') as CollectionReference<Game>,
+			where('athlon', '==', doc(db, 'athlons', param.id)),
+			orderBy('order'),
+		),
+	);
+
+	const [name, setName] = createSignal('');
+	const [description, setDescription] = createSignal('');
+	const [gameScores, setGameScores] = createSignal<Record<string, {rawScore: string, tiebreakScore: string, description: string}>>({});
+	const [isSaving, setIsSaving] = createSignal(false);
+
+	createEffect(() => {
+		const record = existingRecordData?.data;
+		if (record) {
+			setName(record.name);
+			setDescription(record.description);
+			const scores: Record<string, {rawScore: string, tiebreakScore: string, description: string}> = {};
+			for (const [gameId, score] of Object.entries(record.scores)) {
+				scores[gameId] = {
+					rawScore: String(score.rawScore),
+					tiebreakScore: String(score.tiebreakScore),
+					description: score.description,
+				};
+			}
+			setGameScores(scores);
+		}
+	});
+
+	const updateGameScore = (gameId: string, field: 'rawScore' | 'tiebreakScore' | 'description', value: string) => {
+		setGameScores((prev) => {
+			const existing = prev[gameId] ?? {rawScore: '0', tiebreakScore: '0', description: ''};
+			return {...prev, [gameId]: {...existing, [field]: value}};
+		});
+	};
+
+	const handleSave = async () => {
+		setIsSaving(true);
+		try {
+			const scores: ReferenceRecord['scores'] = {};
+			for (const [gameId, s] of Object.entries(gameScores())) {
+				const rawScore = Number.parseFloat(s.rawScore);
+				const tiebreakScore = Number.parseFloat(s.tiebreakScore);
+				if (!Number.isFinite(rawScore) || !Number.isFinite(tiebreakScore)) {
+					continue;
+				}
+				scores[gameId] = {rawScore, tiebreakScore, description: s.description};
+			}
+
+			const recordData = {
+				name: name(),
+				description: description(),
+				athlonId: param.id,
+				scores,
+				updatedAt: serverTimestamp(),
+			};
+
+			if (isNew()) {
+				await addDoc(
+					collection(db, 'athlons', param.id, 'referenceRecords') as CollectionReference<ReferenceRecord>,
+					{...recordData, createdAt: serverTimestamp()} as ReferenceRecord,
+				);
+			} else {
+				await setDoc(
+					doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
+					{...recordData, createdAt: existingRecordData?.data?.createdAt ?? serverTimestamp()} as ReferenceRecord,
+				);
+			}
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const pageTitle = () => (isNew() ? '新規参考記録' : `参考記録を編集: ${name()}`);
+
+	return (
+		<main>
+			<Show when={notAdmin()}>
+				<Navigate href={`/athlons/${param.id}`}/>
+			</Show>
+			<Container maxWidth="md" sx={{py: 3}}>
+				<Doc data={athlonData}>
+					{(athlon) => (
+						<PageTitle>[{athlon.name}] {pageTitle()}</PageTitle>
+					)}
+				</Doc>
+				<Breadcrumbs aria-label="breadcrumb" sx={{pb: 3}}>
+					<Link component={A} underline="hover" color="inherit" href="/athlons">
+						Athlons
+					</Link>
+					<Doc data={athlonData}>
+						{(athlon) => (
+							<Link underline="hover" color="inherit" component={A} href={`/athlons/${athlon.id}`}>
+								{athlon.name}
+							</Link>
+						)}
+					</Doc>
+					<Link underline="hover" color="inherit" component={A} href={`/athlons/${param.id}/referenceRecords`}>
+						参考記録管理
+					</Link>
+					<Typography color="text.primary">{isNew() ? '新規' : '編集'}</Typography>
+				</Breadcrumbs>
+				<Typography variant="h4" component="h1" gutterBottom>
+					{pageTitle()}
+				</Typography>
+				<Stack spacing={2}>
+					<TextField
+						fullWidth
+						required
+						label="記録名"
+						value={name()}
+						onChange={(_event, value) => setName(value)}
+					/>
+					<TextField
+						fullWidth
+						multiline
+						minRows={3}
+						label="全体説明 (Markdown)"
+						value={description()}
+						onChange={(_event, value) => setDescription(value)}
+					/>
+					<Divider/>
+					<Typography variant="h6">競技ごとのスコア</Typography>
+					<Collection data={gamesData}>
+						{(game) => {
+							const ruleData = useFirestore(game.rule as DocumentReference<GameRule>);
+							return (
+								<Doc data={ruleData}>
+									{(rule) => (
+										<Stack spacing={1} sx={{p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1}}>
+											<Typography variant="subtitle1" fontWeight="bold">
+												{rule.name}
+											</Typography>
+											<Stack direction="row" spacing={2}>
+												<TextField
+													label="Raw Score"
+													type="number"
+													value={gameScores()[game.id]?.rawScore ?? ''}
+													onChange={(_event, value) => updateGameScore(game.id, 'rawScore', value)}
+													sx={{width: 160}}
+												/>
+												<TextField
+													label="Tiebreak Score"
+													type="number"
+													value={gameScores()[game.id]?.tiebreakScore ?? ''}
+													onChange={(_event, value) => updateGameScore(game.id, 'tiebreakScore', value)}
+													sx={{width: 160}}
+												/>
+											</Stack>
+											<TextField
+												fullWidth
+												multiline
+												minRows={2}
+												label="この競技の説明 (Markdown)"
+												value={gameScores()[game.id]?.description ?? ''}
+												onChange={(_event, value) => updateGameScore(game.id, 'description', value)}
+											/>
+										</Stack>
+									)}
+								</Doc>
+							);
+						}}
+					</Collection>
+					<Button
+						variant="contained"
+						disabled={name() === '' || isSaving()}
+						onClick={handleSave}
+					>
+						{isSaving() ? '保存中…' : '保存'}
+					</Button>
+				</Stack>
+			</Container>
+		</main>
+	);
+};
+
+export default ReferenceRecordEdit;

--- a/src/routes/(home)/athlons/[id]/referenceRecords/index.tsx
+++ b/src/routes/(home)/athlons/[id]/referenceRecords/index.tsx
@@ -1,0 +1,100 @@
+import {A, Navigate, useParams} from '@solidjs/router';
+import {Add} from '@suid/icons-material';
+import {Box, Breadcrumbs, Button, Container, List, ListItem, ListItemButton, ListItemText, Link, Typography} from '@suid/material';
+import {getAuth} from 'firebase/auth';
+import {collection, CollectionReference, doc, DocumentReference, getFirestore} from 'firebase/firestore';
+import {useAuth, useFirebaseApp, useFirestore} from 'solid-firebase';
+import {createEffect, createMemo, createSignal, Show} from 'solid-js';
+import Collection from '~/components/Collection';
+import Doc from '~/components/Doc';
+import PageTitle from '~/components/PageTitle';
+import type {ReferenceRecord, UseFireStoreReturn, User} from '~/lib/schema';
+import useAthlon from '~/lib/useAthlon';
+
+const ReferenceRecordsIndex = () => {
+	const param = useParams<{id: string}>();
+	const app = useFirebaseApp();
+	const db = getFirestore(app);
+	const auth = getAuth(app);
+	const authState = useAuth(auth);
+	const athlonData = useAthlon(param.id);
+
+	const [userData, setUserData] = createSignal<UseFireStoreReturn<User | null | undefined> | null>(null);
+	createEffect(() => {
+		if (authState.data) {
+			const userRef = doc(db, 'users', authState.data.uid) as DocumentReference<User>;
+			setUserData(useFirestore(userRef));
+		}
+	});
+
+	const isAdmin = createMemo(() => userData()?.data?.isAdmin === true);
+	const notAdmin = createMemo(() => (
+		!authState.loading &&
+		(userData() !== null) &&
+		!isAdmin()
+	));
+
+	const referenceRecordsData = useFirestore(
+		collection(db, 'athlons', param.id, 'referenceRecords') as CollectionReference<ReferenceRecord>,
+	);
+
+	return (
+		<main>
+			<Show when={notAdmin()}>
+				<Navigate href={`/athlons/${param.id}`}/>
+			</Show>
+			<Container maxWidth="md" sx={{py: 3}}>
+				<Doc data={athlonData}>
+					{(athlon) => (
+						<PageTitle>[{athlon.name}] 参考記録管理</PageTitle>
+					)}
+				</Doc>
+				<Breadcrumbs aria-label="breadcrumb" sx={{pb: 3}}>
+					<Link component={A} underline="hover" color="inherit" href="/athlons">
+						Athlons
+					</Link>
+					<Doc data={athlonData}>
+						{(athlon) => (
+							<Link underline="hover" color="inherit" component={A} href={`/athlons/${athlon.id}`}>
+								{athlon.name}
+							</Link>
+						)}
+					</Doc>
+					<Typography color="text.primary">参考記録管理</Typography>
+				</Breadcrumbs>
+				<Typography variant="h4" component="h1" gutterBottom>
+					参考記録管理
+				</Typography>
+				<Box sx={{mb: 2}}>
+					<Button
+						variant="contained"
+						startIcon={<Add/>}
+						component={A}
+						href={`/athlons/${param.id}/referenceRecords/new`}
+					>
+						新規参考記録を追加
+					</Button>
+				</Box>
+				<Collection
+					data={referenceRecordsData}
+					empty={<Typography color="text.secondary">参考記録はまだありません。</Typography>}
+				>
+					{(record) => (
+						<List>
+							<ListItem disablePadding>
+								<ListItemButton component={A} href={`/athlons/${param.id}/referenceRecords/${record.id}`}>
+									<ListItemText
+										primary={record.name}
+										secondary={record.description.slice(0, 100) || '説明なし'}
+									/>
+								</ListItemButton>
+							</ListItem>
+						</List>
+					)}
+				</Collection>
+			</Container>
+		</main>
+	);
+};
+
+export default ReferenceRecordsIndex;


### PR DESCRIPTION
## Summary

- 管理者がathlon内の各競技に対して参考記録（AIエージェントのスコアなど）を登録できる機能を追加
- 参考記録はランキング内に通常ユーザーと同様に表示されるが、他の参加者の点数計算には影響しない
- 各ゲーム終了後にのみ公開される（Firestore rules では常に readable、UI で表示制御）

## Changes

**Schema / Rules**
- `ReferenceRecord` / `ReferenceRecordGameScore` 型を `schema.d.ts` に追加
- `RankingEntry` に `referenceRecordId?: string` を追加
- Firestore rules に `athlons/{athlonId}/referenceRecords` ルールを追加（常に read 可、write は global admin のみ）

**Scoring (`lib/scores.ts`)**
- `calculateReferenceScore` を追加：`max-ratio` 型では実ユーザーの最高点を基準にし、参考記録がそれを超えた場合は満点

**Cloud Functions**
- `calculateReferenceRecordRankings`: 参考記録の仮順位・点数を計算（実ユーザーランキングに挿入した場合の順位を算出）
- `onScoreChanged` 拡張：ユーザーランキング計算後に参考記録ランキングも同一トランザクション内で更新
- `onReferenceRecordWritten` 新設：参考記録の作成・更新・削除時にランキングを再計算
- `onRankingWritten` に `ref_` プレフィックスのスキップを追加（`participationCount` 誤更新防止）
- `rankings/ref_{recordId}` エントリを削除ロジックから除外

**UI**
- `/athlons/[id]/referenceRecords/` — 参考記録一覧ページ（admin のみアクセス可）
- `/athlons/[id]/referenceRecords/[recordId]` — 参考記録の作成・編集フォーム（`recordId=new` で新規作成）
- athlon 全体 leaderboard：終了後に参考記録をグレー行＋「参考」チップで混在表示（点数降順ソート）
- ゲーム別 leaderboard：当該ゲーム終了後に参考記録行を追加表示
- athlon トップページの `RankingSummary` から参考記録を除外

## Test plan

- [ ] 管理者ユーザーで `/athlons/{id}/referenceRecords/new` にアクセスし、参考記録を作成できること
- [ ] 非管理者ユーザーがアクセスするとトップにリダイレクトされること
- [ ] 参考記録作成後、Cloud Functions が `rankings/ref_{recordId}` を生成すること
- [ ] ゲーム終了前はランキングに参考記録が表示されないこと
- [ ] ゲーム終了後はゲーム別ランキングに「参考」バッジ付きで表示されること
- [ ] athlon 終了後は全体ランキングに「参考」バッジ付きで表示されること
- [ ] 参加者数カウントに参考記録が含まれないこと

🤖 Generated with [Claude Code](https://claude.ai/claude-code)