### PR TITLE
Fix FirebaseError on /athlons caused by reference record rankings

### DIFF
--- a/src/routes/(home)/athlons/index.tsx
+++ b/src/routes/(home)/athlons/index.tsx
@@ -62,7 +62,7 @@ const Athlons = () => {
 									<Doc data={athlonRankingsData}>
 										{(athlonRankings) => {
 											const athlonRanking = athlonRankings
-												.filter((ranking) => ranking.athlonId === athlon.id)
+												.filter((ranking) => ranking.athlonId === athlon.id && !ranking.referenceRecordId)
 												.sort((a, b) => a.rank - b.rank);
 
 											return (


### PR DESCRIPTION
## Summary

- `/athlons` ページで `FirebaseError: Invalid document reference. Document references must have an even number of segments, but users has 1.` が発生していた
- `collectionGroup('rankings')` は reference record の ranking（`userId: ''`）も取得するが、フィルターで除外されておらず `Username` コンポーネントに渡されていた
- `Username` 内で `doc(db, 'users', '')` が呼ばれ、パスが `users`（1セグメント）になりエラーが発生
- `referenceRecordId` を持つ ranking を filter で除外することで修正

## Root cause

`functions/src/scores.ts` の `calculateReferenceRecordRankings` は reference record ranking を `userId: ''` で返す。これが `athlons/{id}/rankings/ref_{recordId}` に保存され、`collectionGroup('rankings')` でフロントエンドが全件取得する際に含まれていた。

## Test plan

- [ ] `/athlons` ページを開いてエラーが出ないことを確認
- [ ] 各アスロンの上位ランカーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)