### PR TITLE
feat: add public reference record detail pages with per-game breakdown

### DIFF
--- a/src/routes/(home)/athlons/[id]/[ruleId]/leaderboard.tsx
+++ b/src/routes/(home)/athlons/[id]/[ruleId]/leaderboard.tsx
@@ -187,7 +187,14 @@ const Leaderboard = () => {
 																		</TableCell>
 																		<TableCell>
 																			<Stack direction="row" alignItems="center" gap={1}>
-																				<span>{record?.name ?? ranking.referenceRecordId}</span>
+																				<Link
+																					component={A}
+																					href={`/athlons/${param.id}/referenceRecords/${ranking.referenceRecordId}/${param.ruleId}`}
+																					underline="hover"
+																					color="inherit"
+																				>
+																					{record?.name ?? ranking.referenceRecordId}
+																				</Link>
 																				<Chip label="参考" size="small" variant="outlined" color="default"/>
 																			</Stack>
 																		</TableCell>

--- a/src/routes/(home)/athlons/[id]/leaderboard.tsx
+++ b/src/routes/(home)/athlons/[id]/leaderboard.tsx
@@ -200,7 +200,14 @@ const RankingTable = (props: RankingTableProps) => {
 													</Stack>
 												}
 											>
-												<span>{refName()}</span>
+												<Link
+													component={A}
+													href={`/athlons/${props.athlonId}/referenceRecords/${userEntry.referenceRecordId}`}
+													underline="hover"
+													color="inherit"
+												>
+													{refName()}
+												</Link>
 												<Chip label="参考" size="small" variant="outlined" color="default"/>
 											</Show>
 										</Stack>

--- a/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/[ruleId]/index.tsx
+++ b/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/[ruleId]/index.tsx
@@ -1,0 +1,182 @@
+import {Link} from '@solidjs/meta';
+import {A, useParams} from '@solidjs/router';
+import {Breadcrumbs, Chip, Container, Divider, Link as LinkUi, Stack, Typography} from '@suid/material';
+import {collection, CollectionReference, doc, DocumentReference, getFirestore, query, where} from 'firebase/firestore';
+import remarkGfm from 'remark-gfm';
+import {floor} from 'remeda';
+import {useFirebaseApp, useFirestore} from 'solid-firebase';
+import {createEffect, createMemo, Show} from 'solid-js';
+import {SolidMarkdown} from 'solid-markdown';
+import Collection from '~/components/Collection';
+import Doc from '~/components/Doc';
+import PageTitle from '~/components/PageTitle';
+import type {AthlonRanking, Game, GameRule, ReferenceRecord} from '~/lib/schema';
+import useAthlon from '~/lib/useAthlon';
+
+const MarkdownWithMath = (props: {content: string}) => {
+	let containerRef!: HTMLDivElement;
+
+	createEffect(async () => {
+		// @ts-expect-error: URL import
+		// eslint-disable-next-line import/no-unresolved
+		const {default: renderMathInElement} = await import('https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.mjs');
+		renderMathInElement(containerRef, {
+			delimiters: [
+				{left: '$$', right: '$$', display: true},
+				{left: '$', right: '$', display: false},
+			],
+		});
+	});
+
+	return (
+		<div ref={containerRef}>
+			<SolidMarkdown class="markdown" children={props.content} remarkPlugins={[remarkGfm]} linkTarget="_blank"/>
+		</div>
+	);
+};
+
+const ReferenceRecordGameDetail = () => {
+	const param = useParams<{id: string, recordId: string, ruleId: string}>();
+	const app = useFirebaseApp();
+	const db = getFirestore(app);
+	const athlonData = useAthlon(param.id);
+
+	const ruleRef = doc(db, 'gameRules', param.ruleId) as DocumentReference<GameRule>;
+	const ruleData = useFirestore(ruleRef);
+
+	const recordData = useFirestore(
+		doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
+	);
+
+	const gameData = useFirestore(
+		query(
+			collection(db, 'games') as CollectionReference<Game>,
+			where('athlon', '==', doc(db, 'athlons', param.id)),
+			where('rule', '==', ruleRef),
+		),
+	);
+
+	const rankingData = useFirestore(
+		query(
+			collection(db, 'athlons', param.id, 'rankings') as CollectionReference<AthlonRanking>,
+			where('referenceRecordId', '==', param.recordId),
+		),
+	);
+
+	const ranking = createMemo(() => rankingData.data?.[0]);
+
+	return (
+		<main>
+			<Link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css"/>
+			<Container maxWidth="md" sx={{py: 3}}>
+				<Doc data={athlonData}>
+					{(athlon) => (
+						<Doc data={recordData}>
+							{(record) => (
+								<Doc data={ruleData}>
+									{(rule) => (
+										<PageTitle>[{athlon.name}] {record.name} — {rule.name}</PageTitle>
+									)}
+								</Doc>
+							)}
+						</Doc>
+					)}
+				</Doc>
+				<Breadcrumbs aria-label="breadcrumb" sx={{pb: 3}}>
+					<LinkUi component={A} underline="hover" color="inherit" href="/athlons">
+						Athlons
+					</LinkUi>
+					<Doc data={athlonData}>
+						{(athlon) => (
+							<LinkUi underline="hover" color="inherit" component={A} href={`/athlons/${athlon.id}`}>
+								{athlon.name}
+							</LinkUi>
+						)}
+					</Doc>
+					<Doc data={recordData}>
+						{(record) => (
+							<LinkUi
+								underline="hover"
+								color="inherit"
+								component={A}
+								href={`/athlons/${param.id}/referenceRecords/${param.recordId}`}
+							>
+								{record.name}
+							</LinkUi>
+						)}
+					</Doc>
+					<Doc data={ruleData}>
+						{(rule) => (
+							<Typography color="text.primary">{rule.name}</Typography>
+						)}
+					</Doc>
+				</Breadcrumbs>
+				<Doc data={recordData} fallback={<Typography color="text.secondary">参考記録が見つかりません。</Typography>}>
+					{(record) => (
+						<Collection data={gameData} empty={<Typography color="text.secondary">競技が見つかりません。</Typography>}>
+							{(game) => {
+								const score = record.scores[game.id];
+								const gameRanking = createMemo(() => ranking()?.games.find((g) => g.gameId === game.id));
+								return (
+									<Show when={score} keyed>
+										{(s) => (
+											<Stack spacing={3}>
+												<Doc data={ruleData}>
+													{(rule) => (
+														<Stack direction="row" alignItems="center" flexWrap="wrap" gap={1}>
+															<Typography variant="h4" component="h1">
+																{record.name}
+															</Typography>
+															<Chip label="参考記録" variant="outlined" size="small"/>
+															<Typography variant="h5" component="span" color="text.secondary">
+																— {rule.name}
+															</Typography>
+														</Stack>
+													)}
+												</Doc>
+												<Stack direction="row" spacing={4} alignItems="baseline">
+													<Stack alignItems="center">
+														<Typography variant="caption" color="text.secondary">Point</Typography>
+														<Show
+															when={gameRanking()}
+															keyed
+															fallback={<Typography variant="h4" color="text.secondary">—</Typography>}
+														>
+															{(r) => (
+																<Typography variant="h4">
+																	<strong>{floor(r.point, 2).toFixed(2)}</strong>
+																</Typography>
+															)}
+														</Show>
+													</Stack>
+													<Stack alignItems="center">
+														<Typography variant="caption" color="text.secondary">Raw Score</Typography>
+														<Typography variant="h6">{s.rawScore}</Typography>
+													</Stack>
+													<Stack alignItems="center">
+														<Typography variant="caption" color="text.secondary">Tiebreak</Typography>
+														<Typography variant="h6">{s.tiebreakScore}</Typography>
+													</Stack>
+												</Stack>
+												<Show when={record.description}>
+													<Divider/>
+													<MarkdownWithMath content={record.description}/>
+												</Show>
+												<Show when={s.description}>
+													<Divider/>
+													<MarkdownWithMath content={s.description}/>
+												</Show>
+											</Stack>
+										)}
+									</Show>
+								);
+							}}
+						</Collection>
+					)}
+				</Doc>
+			</Container>
+		</main>
+	);
+};
+
+export default ReferenceRecordGameDetail;

--- a/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/edit.tsx
+++ b/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/edit.tsx
@@ -1,0 +1,213 @@
+import {A, Navigate, useParams} from '@solidjs/router';
+import {Breadcrumbs, Button, Container, Divider, Link, Stack, TextField, Typography} from '@suid/material';
+import {getAuth} from 'firebase/auth';
+import {addDoc, collection, CollectionReference, doc, DocumentReference, getFirestore, orderBy, query, serverTimestamp, setDoc, where} from 'firebase/firestore';
+import {useAuth, useFirebaseApp, useFirestore} from 'solid-firebase';
+import {createEffect, createMemo, createSignal, Show} from 'solid-js';
+import Collection from '~/components/Collection';
+import Doc from '~/components/Doc';
+import PageTitle from '~/components/PageTitle';
+import type {Game, GameRule, ReferenceRecord, UseFireStoreReturn, User} from '~/lib/schema';
+import useAthlon from '~/lib/useAthlon';
+
+const ReferenceRecordEdit = () => {
+	const param = useParams<{id: string, recordId: string}>();
+	const isNew = () => param.recordId === 'new';
+	const app = useFirebaseApp();
+	const db = getFirestore(app);
+	const auth = getAuth(app);
+	const authState = useAuth(auth);
+	const athlonData = useAthlon(param.id);
+
+	const [userData, setUserData] = createSignal<UseFireStoreReturn<User | null | undefined> | null>(null);
+	createEffect(() => {
+		if (authState.data) {
+			const userRef = doc(db, 'users', authState.data.uid) as DocumentReference<User>;
+			setUserData(useFirestore(userRef));
+		}
+	});
+
+	const notAdmin = createMemo(() => userData()?.data?.isAdmin === false);
+
+	const existingRecordData = useFirestore(
+		doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
+	);
+
+	const gamesData = useFirestore(
+		query(
+			collection(db, 'games') as CollectionReference<Game>,
+			where('athlon', '==', doc(db, 'athlons', param.id)),
+			orderBy('order'),
+		),
+	);
+
+	const [name, setName] = createSignal('');
+	const [description, setDescription] = createSignal('');
+	const [gameScores, setGameScores] = createSignal<Record<string, {rawScore: string, tiebreakScore: string, description: string}>>({});
+	const [isSaving, setIsSaving] = createSignal(false);
+
+	createEffect(() => {
+		const record = existingRecordData?.data;
+		if (record) {
+			setName(record.name);
+			setDescription(record.description);
+			const scores: Record<string, {rawScore: string, tiebreakScore: string, description: string}> = {};
+			for (const [gameId, score] of Object.entries(record.scores)) {
+				scores[gameId] = {
+					rawScore: String(score.rawScore),
+					tiebreakScore: String(score.tiebreakScore),
+					description: score.description,
+				};
+			}
+			setGameScores(scores);
+		}
+	});
+
+	const updateGameScore = (gameId: string, field: 'rawScore' | 'tiebreakScore' | 'description', value: string) => {
+		setGameScores((prev) => {
+			const existing = prev[gameId] ?? {rawScore: '0', tiebreakScore: '0', description: ''};
+			return {...prev, [gameId]: {...existing, [field]: value}};
+		});
+	};
+
+	const handleSave = async () => {
+		setIsSaving(true);
+		try {
+			const scores: ReferenceRecord['scores'] = {};
+			for (const [gameId, s] of Object.entries(gameScores())) {
+				const rawScore = Number.parseFloat(s.rawScore);
+				const tiebreakScore = Number.parseFloat(s.tiebreakScore);
+				if (!Number.isFinite(rawScore) || !Number.isFinite(tiebreakScore)) {
+					continue;
+				}
+				scores[gameId] = {rawScore, tiebreakScore, description: s.description};
+			}
+
+			const recordData = {
+				name: name(),
+				description: description(),
+				athlonId: param.id,
+				scores,
+				updatedAt: serverTimestamp(),
+			};
+
+			if (isNew()) {
+				await addDoc(
+					collection(db, 'athlons', param.id, 'referenceRecords') as CollectionReference<ReferenceRecord>,
+					{...recordData, createdAt: serverTimestamp()} as ReferenceRecord,
+				);
+			} else {
+				await setDoc(
+					doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
+					{...recordData, createdAt: existingRecordData?.data?.createdAt ?? serverTimestamp()} as ReferenceRecord,
+				);
+			}
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const pageTitle = () => (isNew() ? '新規参考記録' : `参考記録を編集: ${name()}`);
+
+	return (
+		<main>
+			<Show when={notAdmin()}>
+				<Navigate href={`/athlons/${param.id}`}/>
+			</Show>
+			<Container maxWidth="md" sx={{py: 3}}>
+				<Doc data={athlonData}>
+					{(athlon) => (
+						<PageTitle>[{athlon.name}] {pageTitle()}</PageTitle>
+					)}
+				</Doc>
+				<Breadcrumbs aria-label="breadcrumb" sx={{pb: 3}}>
+					<Link component={A} underline="hover" color="inherit" href="/athlons">
+						Athlons
+					</Link>
+					<Doc data={athlonData}>
+						{(athlon) => (
+							<Link underline="hover" color="inherit" component={A} href={`/athlons/${athlon.id}`}>
+								{athlon.name}
+							</Link>
+						)}
+					</Doc>
+					<Link underline="hover" color="inherit" component={A} href={`/athlons/${param.id}/referenceRecords`}>
+						参考記録管理
+					</Link>
+					<Typography color="text.primary">{isNew() ? '新規' : '編集'}</Typography>
+				</Breadcrumbs>
+				<Typography variant="h4" component="h1" gutterBottom>
+					{pageTitle()}
+				</Typography>
+				<Stack spacing={2}>
+					<TextField
+						fullWidth
+						required
+						label="記録名"
+						value={name()}
+						onChange={(_event, value) => setName(value)}
+					/>
+					<TextField
+						fullWidth
+						multiline
+						minRows={3}
+						label="全体説明 (Markdown)"
+						value={description()}
+						onChange={(_event, value) => setDescription(value)}
+					/>
+					<Divider/>
+					<Typography variant="h6">競技ごとのスコア</Typography>
+					<Collection data={gamesData}>
+						{(game) => {
+							const ruleData = useFirestore(game.rule as DocumentReference<GameRule>);
+							return (
+								<Doc data={ruleData}>
+									{(rule) => (
+										<Stack spacing={1} sx={{p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1}}>
+											<Typography variant="subtitle1" fontWeight="bold">
+												{rule.name}
+											</Typography>
+											<Stack direction="row" spacing={2}>
+												<TextField
+													label="Raw Score"
+													type="number"
+													value={gameScores()[game.id]?.rawScore ?? ''}
+													onChange={(_event, value) => updateGameScore(game.id, 'rawScore', value)}
+													sx={{width: 160}}
+												/>
+												<TextField
+													label="Tiebreak Score"
+													type="number"
+													value={gameScores()[game.id]?.tiebreakScore ?? ''}
+													onChange={(_event, value) => updateGameScore(game.id, 'tiebreakScore', value)}
+													sx={{width: 160}}
+												/>
+											</Stack>
+											<TextField
+												fullWidth
+												multiline
+												minRows={2}
+												label="この競技の説明 (Markdown)"
+												value={gameScores()[game.id]?.description ?? ''}
+												onChange={(_event, value) => updateGameScore(game.id, 'description', value)}
+											/>
+										</Stack>
+									)}
+								</Doc>
+							);
+						}}
+					</Collection>
+					<Button
+						variant="contained"
+						disabled={name() === '' || isSaving()}
+						onClick={handleSave}
+					>
+						{isSaving() ? '保存中…' : '保存'}
+					</Button>
+				</Stack>
+			</Container>
+		</main>
+	);
+};
+
+export default ReferenceRecordEdit;

--- a/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/index.tsx
+++ b/src/routes/(home)/athlons/[id]/referenceRecords/[recordId]/index.tsx
@@ -1,35 +1,22 @@
-import {A, Navigate, useParams} from '@solidjs/router';
-import {Breadcrumbs, Button, Container, Divider, Link, Stack, TextField, Typography} from '@suid/material';
-import {getAuth} from 'firebase/auth';
-import {addDoc, collection, CollectionReference, doc, DocumentReference, getFirestore, orderBy, query, serverTimestamp, setDoc, where} from 'firebase/firestore';
-import {useAuth, useFirebaseApp, useFirestore} from 'solid-firebase';
-import {createEffect, createMemo, createSignal, Show} from 'solid-js';
+import {A, useParams} from '@solidjs/router';
+import {Breadcrumbs, Chip, Container, Link as LinkUi, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography} from '@suid/material';
+import {collection, CollectionReference, doc, DocumentReference, getFirestore, orderBy, query, where} from 'firebase/firestore';
+import {floor} from 'remeda';
+import {useFirebaseApp, useFirestore} from 'solid-firebase';
+import {createMemo, Show} from 'solid-js';
 import Collection from '~/components/Collection';
 import Doc from '~/components/Doc';
 import PageTitle from '~/components/PageTitle';
-import type {Game, GameRule, ReferenceRecord, UseFireStoreReturn, User} from '~/lib/schema';
+import type {AthlonRanking, Game, GameRule, ReferenceRecord} from '~/lib/schema';
 import useAthlon from '~/lib/useAthlon';
 
-const ReferenceRecordEdit = () => {
+const ReferenceRecordDetail = () => {
 	const param = useParams<{id: string, recordId: string}>();
-	const isNew = () => param.recordId === 'new';
 	const app = useFirebaseApp();
 	const db = getFirestore(app);
-	const auth = getAuth(app);
-	const authState = useAuth(auth);
 	const athlonData = useAthlon(param.id);
 
-	const [userData, setUserData] = createSignal<UseFireStoreReturn<User | null | undefined> | null>(null);
-	createEffect(() => {
-		if (authState.data) {
-			const userRef = doc(db, 'users', authState.data.uid) as DocumentReference<User>;
-			setUserData(useFirestore(userRef));
-		}
-	});
-
-	const notAdmin = createMemo(() => userData()?.data?.isAdmin === false);
-
-	const existingRecordData = useFirestore(
+	const recordData = useFirestore(
 		doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
 	);
 
@@ -41,173 +28,123 @@ const ReferenceRecordEdit = () => {
 		),
 	);
 
-	const [name, setName] = createSignal('');
-	const [description, setDescription] = createSignal('');
-	const [gameScores, setGameScores] = createSignal<Record<string, {rawScore: string, tiebreakScore: string, description: string}>>({});
-	const [isSaving, setIsSaving] = createSignal(false);
+	const rankingData = useFirestore(
+		query(
+			collection(db, 'athlons', param.id, 'rankings') as CollectionReference<AthlonRanking>,
+			where('referenceRecordId', '==', param.recordId),
+		),
+	);
 
-	createEffect(() => {
-		const record = existingRecordData?.data;
-		if (record) {
-			setName(record.name);
-			setDescription(record.description);
-			const scores: Record<string, {rawScore: string, tiebreakScore: string, description: string}> = {};
-			for (const [gameId, score] of Object.entries(record.scores)) {
-				scores[gameId] = {
-					rawScore: String(score.rawScore),
-					tiebreakScore: String(score.tiebreakScore),
-					description: score.description,
-				};
-			}
-			setGameScores(scores);
-		}
-	});
-
-	const updateGameScore = (gameId: string, field: 'rawScore' | 'tiebreakScore' | 'description', value: string) => {
-		setGameScores((prev) => {
-			const existing = prev[gameId] ?? {rawScore: '0', tiebreakScore: '0', description: ''};
-			return {...prev, [gameId]: {...existing, [field]: value}};
-		});
-	};
-
-	const handleSave = async () => {
-		setIsSaving(true);
-		try {
-			const scores: ReferenceRecord['scores'] = {};
-			for (const [gameId, s] of Object.entries(gameScores())) {
-				const rawScore = Number.parseFloat(s.rawScore);
-				const tiebreakScore = Number.parseFloat(s.tiebreakScore);
-				if (!Number.isFinite(rawScore) || !Number.isFinite(tiebreakScore)) {
-					continue;
-				}
-				scores[gameId] = {rawScore, tiebreakScore, description: s.description};
-			}
-
-			const recordData = {
-				name: name(),
-				description: description(),
-				athlonId: param.id,
-				scores,
-				updatedAt: serverTimestamp(),
-			};
-
-			if (isNew()) {
-				await addDoc(
-					collection(db, 'athlons', param.id, 'referenceRecords') as CollectionReference<ReferenceRecord>,
-					{...recordData, createdAt: serverTimestamp()} as ReferenceRecord,
-				);
-			} else {
-				await setDoc(
-					doc(db, 'athlons', param.id, 'referenceRecords', param.recordId) as DocumentReference<ReferenceRecord>,
-					{...recordData, createdAt: existingRecordData?.data?.createdAt ?? serverTimestamp()} as ReferenceRecord,
-				);
-			}
-		} finally {
-			setIsSaving(false);
-		}
-	};
-
-	const pageTitle = () => (isNew() ? '新規参考記録' : `参考記録を編集: ${name()}`);
+	const ranking = createMemo(() => rankingData.data?.[0]);
 
 	return (
 		<main>
-			<Show when={notAdmin()}>
-				<Navigate href={`/athlons/${param.id}`}/>
-			</Show>
 			<Container maxWidth="md" sx={{py: 3}}>
 				<Doc data={athlonData}>
 					{(athlon) => (
-						<PageTitle>[{athlon.name}] {pageTitle()}</PageTitle>
+						<Doc data={recordData}>
+							{(record) => (
+								<PageTitle>[{athlon.name}] {record.name}</PageTitle>
+							)}
+						</Doc>
 					)}
 				</Doc>
 				<Breadcrumbs aria-label="breadcrumb" sx={{pb: 3}}>
-					<Link component={A} underline="hover" color="inherit" href="/athlons">
+					<LinkUi component={A} underline="hover" color="inherit" href="/athlons">
 						Athlons
-					</Link>
+					</LinkUi>
 					<Doc data={athlonData}>
 						{(athlon) => (
-							<Link underline="hover" color="inherit" component={A} href={`/athlons/${athlon.id}`}>
+							<LinkUi underline="hover" color="inherit" component={A} href={`/athlons/${athlon.id}`}>
 								{athlon.name}
-							</Link>
+							</LinkUi>
 						)}
 					</Doc>
-					<Link underline="hover" color="inherit" component={A} href={`/athlons/${param.id}/referenceRecords`}>
-						参考記録管理
-					</Link>
-					<Typography color="text.primary">{isNew() ? '新規' : '編集'}</Typography>
+					<Doc data={recordData}>
+						{(record) => (
+							<Typography color="text.primary">{record.name}</Typography>
+						)}
+					</Doc>
 				</Breadcrumbs>
-				<Typography variant="h4" component="h1" gutterBottom>
-					{pageTitle()}
-				</Typography>
-				<Stack spacing={2}>
-					<TextField
-						fullWidth
-						required
-						label="記録名"
-						value={name()}
-						onChange={(_event, value) => setName(value)}
-					/>
-					<TextField
-						fullWidth
-						multiline
-						minRows={3}
-						label="全体説明 (Markdown)"
-						value={description()}
-						onChange={(_event, value) => setDescription(value)}
-					/>
-					<Divider/>
-					<Typography variant="h6">競技ごとのスコア</Typography>
-					<Collection data={gamesData}>
-						{(game) => {
-							const ruleData = useFirestore(game.rule as DocumentReference<GameRule>);
-							return (
-								<Doc data={ruleData}>
-									{(rule) => (
-										<Stack spacing={1} sx={{p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1}}>
-											<Typography variant="subtitle1" fontWeight="bold">
-												{rule.name}
-											</Typography>
-											<Stack direction="row" spacing={2}>
-												<TextField
-													label="Raw Score"
-													type="number"
-													value={gameScores()[game.id]?.rawScore ?? ''}
-													onChange={(_event, value) => updateGameScore(game.id, 'rawScore', value)}
-													sx={{width: 160}}
-												/>
-												<TextField
-													label="Tiebreak Score"
-													type="number"
-													value={gameScores()[game.id]?.tiebreakScore ?? ''}
-													onChange={(_event, value) => updateGameScore(game.id, 'tiebreakScore', value)}
-													sx={{width: 160}}
-												/>
-											</Stack>
-											<TextField
-												fullWidth
-												multiline
-												minRows={2}
-												label="この競技の説明 (Markdown)"
-												value={gameScores()[game.id]?.description ?? ''}
-												onChange={(_event, value) => updateGameScore(game.id, 'description', value)}
-											/>
-										</Stack>
+				<Doc data={recordData} fallback={<Typography color="text.secondary">参考記録が見つかりません。</Typography>}>
+					{(record) => (
+						<Stack spacing={3}>
+							<Stack direction="row" alignItems="center" spacing={2}>
+								<Typography variant="h4" component="h1">
+									{record.name}
+								</Typography>
+								<Chip label="参考記録" variant="outlined" size="small"/>
+								<Show when={ranking()} keyed>
+									{(r) => (
+										<Typography variant="h5" color="text.secondary">
+											{floor(r.point, 2).toFixed(2)} pt
+										</Typography>
 									)}
-								</Doc>
-							);
-						}}
-					</Collection>
-					<Button
-						variant="contained"
-						disabled={name() === '' || isSaving()}
-						onClick={handleSave}
-					>
-						{isSaving() ? '保存中…' : '保存'}
-					</Button>
-				</Stack>
+								</Show>
+							</Stack>
+							<TableContainer component={Paper}>
+								<Table>
+									<TableHead>
+										<TableRow>
+											<TableCell>競技</TableCell>
+											<TableCell align="right">Point</TableCell>
+											<TableCell align="right">Raw Score</TableCell>
+											<TableCell align="right">Tiebreak</TableCell>
+										</TableRow>
+									</TableHead>
+									<TableBody>
+										<Collection data={gamesData}>
+											{(game) => {
+												const ruleData = useFirestore(game.rule as DocumentReference<GameRule>);
+												const score = record.scores[game.id];
+												const gameRanking = createMemo(() => ranking()?.games.find((g) => g.gameId === game.id));
+												return (
+													<Show when={score} keyed>
+														{(s) => (
+															<Doc data={ruleData}>
+																{(rule) => (
+																	<TableRow>
+																		<TableCell>
+																			<LinkUi
+																				component={A}
+																				underline="hover"
+																				href={`/athlons/${param.id}/referenceRecords/${param.recordId}/${rule.id}`}
+																			>
+																				{rule.name}
+																			</LinkUi>
+																		</TableCell>
+																		<TableCell align="right">
+																			<Show
+																				when={gameRanking()}
+																				keyed
+																				fallback={<Typography component="span" color="text.secondary">—</Typography>}
+																			>
+																				{(r) => (
+																					<Typography variant="h6" component="span">
+																						{floor(r.point, 2).toFixed(2)}
+																					</Typography>
+																				)}
+																			</Show>
+																		</TableCell>
+																		<TableCell align="right">{s.rawScore}</TableCell>
+																		<TableCell align="right">{s.tiebreakScore}</TableCell>
+																	</TableRow>
+																)}
+															</Doc>
+														)}
+													</Show>
+												);
+											}}
+										</Collection>
+									</TableBody>
+								</Table>
+							</TableContainer>
+						</Stack>
+					)}
+				</Doc>
 			</Container>
 		</main>
 	);
 };
 
-export default ReferenceRecordEdit;
+export default ReferenceRecordDetail;

--- a/src/routes/(home)/athlons/[id]/referenceRecords/index.tsx
+++ b/src/routes/(home)/athlons/[id]/referenceRecords/index.tsx
@@ -65,7 +65,7 @@ const ReferenceRecordsIndex = () => {
 						variant="contained"
 						startIcon={<Add/>}
 						component={A}
-						href={`/athlons/${param.id}/referenceRecords/new`}
+						href={`/athlons/${param.id}/referenceRecords/new/edit`}
 					>
 						新規参考記録を追加
 					</Button>
@@ -77,7 +77,7 @@ const ReferenceRecordsIndex = () => {
 					{(record) => (
 						<List>
 							<ListItem disablePadding>
-								<ListItemButton component={A} href={`/athlons/${param.id}/referenceRecords/${record.id}`}>
+								<ListItemButton component={A} href={`/athlons/${param.id}/referenceRecords/${record.id}/edit`}>
 									<ListItemText
 										primary={record.name}
 										secondary={record.description.slice(0, 100) || '説明なし'}


### PR DESCRIPTION
## Summary

- 参考記録の一般公開閲覧ページを `/athlons/[id]/referenceRecords/[recordId]` に追加（各競技のRankingポイントをテーブルで目立つ表示）
- 競技別詳細ページを `/athlons/[id]/referenceRecords/[recordId]/[ruleId]` に追加（Markdown+KaTeXでdescriptionをレンダリング、Pointをh4で最も目立つ表示）
- Admin編集ページを `[recordId]/index.tsx` → `[recordId]/edit.tsx` に移動（URL: `/edit` サフィックス）
- Adminリストページのリンクを編集ページに更新
- ランキングページの参考記録名リンクを詳細ページへ変更（athlon全体LB→記録詳細、競技別LB→競技別詳細）

## Test plan

- [ ] `/athlons/{id}/referenceRecords/{recordId}` で参考記録詳細が表示される
- [ ] 各競技のPointがh6で目立って表示され、Raw Score/Tiebreakは通常サイズ
- [ ] 競技名クリックで `/athlons/{id}/referenceRecords/{recordId}/{ruleId}` へ遷移
- [ ] 競技別詳細ページでPointがh4、描写がMarkdown+KaTeXでレンダリングされる
- [ ] `/athlons/{id}/referenceRecords/{recordId}/edit` でAdmin編集ページが表示される
- [ ] ランキングページの「参考」行の名前クリックで各詳細ページへ遷移
- [ ] 非Adminが `/edit` にアクセスするとathlonトップにリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)